### PR TITLE
Fixed Multi Band Mode Issues

### DIFF
--- a/src/instrument/instrument.py
+++ b/src/instrument/instrument.py
@@ -247,7 +247,7 @@ def prep_band(inst, band_key):
     return error_message
 
 
-def run_band(inst, band_key, run_filename, save=True):
+def run_band(inst, band_key, run_filename, band_ori, save=True):
     inst_out_folder = read_settings_from_file()["-INST OUT FOLDER-"]
     local_out_folder = read_settings_from_file()["-LOCAL OUT FOLDER-"]
     sweep_dur = float(read_settings_from_file()["-SWEEP DUR-"])
@@ -268,6 +268,7 @@ def run_band(inst, band_key, run_filename, save=True):
     time.sleep(5)
 
     if save:
-        save_trace_and_screen(inst, run_filename, inst_out_folder, local_out_folder, band_key)
+        band_name = band_key + band_ori
+        save_trace_and_screen(inst, run_filename, inst_out_folder, local_out_folder, band_name)
 
     return error_message

--- a/src/ui/multi_band_mode.py
+++ b/src/ui/multi_band_mode.py
@@ -318,7 +318,8 @@ class MultiModeFrame(ctk.CTkFrame):
         band_range = self.band_range_var.get()
         if band_range == "B5 - B7 (bilogical)":
             self.ori_dropdown.configure(state="normal")
-            self.ori_dropdown.set("Horizontal")
+            if self.ori_var.get() not in ["Horizontal", "Vertical"]:
+                self.ori_dropdown.set("Horizontal")
         else:
             self.ori_dropdown.configure(state="disabled")
             self.ori_dropdown.set("None")
@@ -376,9 +377,6 @@ class MultiModeFrame(ctk.CTkFrame):
         self.frame3.grid(row=3, column=0, padx=5, pady=5, sticky="ew")
         self.fill_frame3(self.frame3)
 
-        # PROGRESS BAR
-        run_times = 1 / num_bands
-
         # updates progress bar to reset
         self.pbar.set(0)
         self.pbar_label.configure(text=f"0/{num_bands}")
@@ -395,7 +393,7 @@ class MultiModeFrame(ctk.CTkFrame):
             self.run_filename = get_run_filename(
                 self.inst, band_key, run_note, self.sweep_dur, band_ori
             )
-            run_band(self.inst, band_key, self.run_filename)
+            run_band(self.inst, band_key, self.run_filename, band_ori)
 
             # Mark checkbox complete
             checkbox, check_var = self.band_checkbox[band_key]
@@ -421,6 +419,8 @@ class MultiModeFrame(ctk.CTkFrame):
         # RUNS COMPLETE
         self.pbar.stop()
         CompletedWindow(self)
+        self.band_checkbox.clear()
+        self.band_filenames.clear()
         self.frame3.grid_forget()  # hide the frame after completion, .destroy() doesn't work here
         self.run_filename = None
         self.after(1, self.enable_buttons())

--- a/src/ui/single_band_mode.py
+++ b/src/ui/single_band_mode.py
@@ -134,7 +134,8 @@ class SingleModeFrame(ctk.CTkFrame):
     def run_single_band(self, band_name):
         # PREPARE, RECORD, ADJUST
         band_key = band_name[:2]
-        error_message = run_band(self.inst, band_key, "", save=False)
+        band_ori = band_name[2] if len(band_name) == 3 else ""
+        error_message = run_band(self.inst, band_key, "", band_ori, save=False)
 
         # GET FILENAME
         run_note = self.run_note_var.get()


### PR DESCRIPTION
There were some underlying issues.
1. Measurements taken in band range B5-B7 in Multi Band Mode were saving to the incorrect folder (refer to issue #77 for more details).
2. The Multi Band Mode orientation dropdown would keep resetting to Horizontal after confirming to run.
3. The Run-ID checklist (issue #51) in Multi Band Mode was not being cleared and caused Autosa to crash.